### PR TITLE
mx6var_som.c - drop superfluous check

### DIFF
--- a/board/variscite/mx6var_som/mx6var_som.c
+++ b/board/variscite/mx6var_som/mx6var_som.c
@@ -1038,9 +1038,6 @@ int board_eth_init(bd_t *bis)
 	}
 #endif
 
-	if (ret)
-		printf("FEC MXC: %s:failed\n", __func__);
-
 #endif /* #if  !defined(CONFIG_SPL_BUILD) */
 	return 0;
 }


### PR DESCRIPTION
Was already tested above the #endif
