### PR TITLE
imx6ul: spl: Increase the SPL MAX Size for mx6ul_var_dart

### DIFF
--- a/include/configs/imx6_spl.h
+++ b/include/configs/imx6_spl.h
@@ -30,7 +30,7 @@
 #define CONFIG_SPL_LDSCRIPT	"arch/arm/mach-omap2/u-boot-spl.lds"
 #if defined(CONFIG_MX6UL)
 #define CONFIG_SPL_TEXT_BASE		0x00909000
-#define CONFIG_SPL_MAX_SIZE		0xF000
+#define CONFIG_SPL_MAX_SIZE		0xFF00
 #else
 #define CONFIG_SPL_TEXT_BASE		0x00908000
 #define CONFIG_SPL_MAX_SIZE		0x10000


### PR DESCRIPTION
This fix the following compile error:

| arm-fslc-linux-gnueabi-ld.bfd: u-boot-spl section `.data' will not fit in
region `.sram'
| arm-fslc-linux-gnueabi-ld.bfd: region `.sram' overflowed by 904 bytes
|   ./tools/mkimage -A arm -T firmware -C none -O u-boot -a 0x86000000 -e 0 -n
"U-Boot 2017.03-mx6ul+g8cd846d for mx6ul_var_dart board" -d u-boot.bin