### PR TITLE
Build config fixes

### DIFF
--- a/arch/arm/mach-imx/Makefile
+++ b/arch/arm/mach-imx/Makefile
@@ -14,7 +14,7 @@ ifneq ($(CONFIG_SPL_BUILD),y)
 obj-$(CONFIG_IMX_BOOTAUX) += imx_bootaux.o
 obj-$(CONFIG_CMD_PROVISION_KEY) += cmd_prov_key.o
 endif
-obj-y += mmc_env.o
+obj-$(CONFIG_ENV_IS_IN_MMC) += mmc_env.o
 obj-$(CONFIG_FEC_MXC) += mac.o
 obj-$(CONFIG_DWC_ETH_QOS) += mac.o
 obj-$(CONFIG_SYS_I2C_MXC) += i2c-mxv7.o
@@ -41,7 +41,7 @@ endif
 ifeq ($(SOC),$(filter $(SOC),mx7))
 obj-y	+= cpu.o
 obj-$(CONFIG_SYS_I2C_MXC) += i2c-mxv7.o
-obj-y += mmc_env.o
+obj-$(CONFIG_ENV_IS_IN_MMC) += mmc_env.o
 endif
 ifeq ($(SOC),$(filter $(SOC),mx7 imx8 imx8m))
 ifneq ($(CONFIG_SPL_BUILD),y)

--- a/board/variscite/imx8mm_var_dart/spl.c
+++ b/board/variscite/imx8mm_var_dart/spl.c
@@ -238,10 +238,10 @@ void spl_board_init(void)
 {
 	struct var_eeprom *ep = VAR_EEPROM_DATA;
 
-if (IS_ENABLED(CONFIG_FSL_CAAM)) {
+#if CONFIG_IS_ENABLED(SPL_CRYPTO) && CONFIG_IS_ENABLED(FSL_CAAM)
 	if (sec_init())
 		printf("\nsec_init failed!\n");
-}
+#endif
 #ifndef CONFIG_SPL_USB_SDP_SUPPORT
 	/* Serial download mode */
 	if (is_usb_boot()) {

--- a/drivers/video/nxp/imx/hdmi/imx8m_hdmi.c
+++ b/drivers/video/nxp/imx/hdmi/imx8m_hdmi.c
@@ -293,7 +293,7 @@ struct dm_display_ops imx8m_hdmi_ops = {
 	.enable =  imx8m_hdmi_enable,
 };
 
-static const struct udevice_id  imx8m_hdmi_ids[] = {
+static const struct udevice_id imx8m_hdmi_ids[] = {
 	{ .compatible = "fsl,imx8mq-hdmi" },
 	{ }
 };

--- a/include/configs/imx8mm_var_dart.h
+++ b/include/configs/imx8mm_var_dart.h
@@ -70,6 +70,12 @@
 	"emmc_dev=2\0"\
 	"sd_dev=1\0" \
 
+#ifdef CONFIG_SYS_MMC_ENV_DEV
+#define BOOTENV_MMCDEV __stringify(CONFIG_SYS_MMC_ENV_DEV)
+#else
+#define BOOTENV_MMCDEV "1"
+#endif
+
 /* Initial environment variables */
 #define CONFIG_EXTRA_ENV_SETTINGS		\
 	CONFIG_MFG_ENV_SETTINGS \
@@ -88,8 +94,8 @@
 	"boot_fit=no\0" \
 	"fdt_file=undefined\0" \
 	"ip_dyn=yes\0" \
-	"mmcdev="__stringify(CONFIG_SYS_MMC_ENV_DEV)"\0" \
-	"mmcblk=1\0" \
+	"mmcdev=" BOOTENV_MMCDEV "\0" \
+	"mmcblk=" BOOTENV_MMCDEV "\0" \
 	"mmcpart=1\0" \
 	"mmcautodetect=yes\0" \
 	"m4_addr=0x7e0000\0" \


### PR DESCRIPTION
These patches fix two build errors. The first one makes it possible to build with DM_RNG (which is required for KASLR). Should I apply this change to other files?

```
% git grep -B2 'sec_init failed'
board/freescale/imx8mm_evk/spl.c-271-   if (IS_ENABLED(CONFIG_FSL_CAAM)) {
board/freescale/imx8mm_evk/spl.c-272-           if (sec_init())
board/freescale/imx8mm_evk/spl.c:273:                   printf("\nsec_init failed!\n");
--
board/freescale/imx8mq_evk/spl.c-206-   if (IS_ENABLED(CONFIG_FSL_CAAM)) {
board/freescale/imx8mq_evk/spl.c-207-           if (sec_init())
board/freescale/imx8mq_evk/spl.c:208:                   printf("\nsec_init failed!\n");
```

The second patch makes it possible to build without `CONFIG_ENV_IS_IN_MMC`.