### PR TITLE
imx8mp_var_dart: Adjust CMA size for SDRAM ≤ 2048MB

### DIFF
--- a/include/configs/imx8mp_var_dart_android.h
+++ b/include/configs/imx8mp_var_dart_android.h
@@ -15,8 +15,7 @@
 #define HW_ENV_SETTINGS \
 	"cmaargs=" \
 		"if test $sdram_size -le 2048; then " \
-			"setenv cmavar 320M@0x400M-0xb80M; " \
-			"setenv galcore_var 'galcore.contiguousSize=33554432'; " \
+			"setenv cmavar 550M@0x400M-0xb80M; " \
 		"else " \
 			"setenv cmavar 1184M@0x400M-0x1000M; " \
 		"fi; " \


### PR DESCRIPTION
Increase the CMA allocation from 320M to 550M when SDRAM size is less than or equal to 2048MB. This provides more memory for multimedia components that rely on contiguous memory.

Removed galcore contiguous size setting, as it is only needed in low-memory (1GB) configurations.

Reference:

ifeq ($(LOW_MEMORY),true)
BOARD_KERNEL_CMDLINE += cma=320M@0x400M-0xb80M galcore.contiguousSize=33554432 BOARD_BOOTCONFIG += androidboot.displaymode=720p
else
BOARD_KERNEL_CMDLINE += cma=$(CMASIZE)@0x400M-0x1000M endif